### PR TITLE
Add missing python 'requests' lib

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ h11==0.14.0
 httptools==0.6.0
 idna==3.4
 openai==0.27.9
+requests==2.31.0
 # slack bot
 fastapi==0.103.0
 aiohttp==3.8.5


### PR DESCRIPTION
Quick fix

This adds missing 'requests' lib to the requirements.txt. The lib has been presented first time in the [resume_handler.py](https://github.com/COXIT-CO/RecruitFlowAI/commit/6671af3dab3ecc9d7bc4d4d144e18182d65448cd#diff-8192d65dbfe968a0e6ed8cc5608e506a1a913852e241bd25120f20be3b9d713e) but the requirements were not updated.